### PR TITLE
fix(security): add API key authentication to protect user endpoints

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,6 @@
+# API Key (required for service authentication)
+export API_KEY=
+
 # App сonfig
 #export CONFIG_PATH=./config/config.toml
 

--- a/src/user_service/presentation/api/controllers/auth.py
+++ b/src/user_service/presentation/api/controllers/auth.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+import os
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+
+@dataclass
+class ApiKeyAuth:
+    """API Key authentication dependency for protecting service endpoints."""
+
+    api_key: str
+
+    @classmethod
+    def from_env(cls) -> "ApiKeyAuth":
+        api_key = os.getenv("API_KEY", "")
+        if not api_key:
+            raise RuntimeError(
+                "API_KEY environment variable is not set. "
+                "Generate one with: python -c 'import secrets; print(secrets.token_urlsafe(32))'"
+            )
+        return cls(api_key=api_key)
+
+    async def __call__(
+        self,
+        credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
+    ) -> None:
+        if credentials.credentials != self.api_key:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid API key",
+            )
+
+
+def get_api_key_auth() -> ApiKeyAuth:
+    """Factory for ApiKeyAuth dependency."""
+    return ApiKeyAuth.from_env()

--- a/src/user_service/presentation/api/controllers/user.py
+++ b/src/user_service/presentation/api/controllers/user.py
@@ -24,6 +24,7 @@ from user_service.domain.user.value_objects.username import (
     WrongUsernameFormatError,
 )
 from user_service.presentation.api.controllers import requests
+from user_service.presentation.api.controllers.auth import ApiKeyAuth, get_api_key_auth
 from user_service.presentation.api.controllers.responses import ErrorResponse
 from user_service.presentation.api.controllers.responses.base import OkResponse
 from user_service.presentation.api.providers.stub import Stub
@@ -31,6 +32,7 @@ from user_service.presentation.api.providers.stub import Stub
 user_router = APIRouter(
     prefix="/users",
     tags=["users"],
+    dependencies=[Depends(get_api_key_auth)],
 )
 
 

--- a/src/user_service/presentation/api/main.py
+++ b/src/user_service/presentation/api/main.py
@@ -1,3 +1,5 @@
+import os
+import sys
 import logging
 
 import uvicorn
@@ -16,6 +18,13 @@ from .config import APIConfig
 logger = logging.getLogger(__name__)
 
 
+def _validate_api_key() -> None:
+    if not os.getenv("API_KEY"):
+        print("fatal: API_KEY environment variable is not set.", file=sys.stderr)
+        print("Generate one with: python -c 'import secrets; print(secrets.token_urlsafe(32))'", file=sys.stderr)
+        sys.exit(1)
+
+
 def init_api(
     mediator: Mediator,
     di_builder: DiBuilder,
@@ -23,6 +32,7 @@ def init_api(
     debug: bool = __debug__,
 ) -> FastAPI:
     logger.debug("Initialize API")
+    _validate_api_key()
     app = FastAPI(
         debug=debug,
         title="User service",


### PR DESCRIPTION
## Summary

All 7 user endpoints (create, read, update, delete) in the REST API were publicly accessible without any authentication. This PR adds Bearer token API key authentication as a router-level dependency, and validates at startup that the API_KEY environment variable is configured.

### Changes

- **New**: `src/user_service/presentation/api/controllers/auth.py` — ApiKeyAuth dependency that validates `Authorization: Bearer <API_KEY>` headers
- **Modified**: `user.py` — Added `dependencies=[Depends(get_api_key_auth)]` to the user_router
- **Modified**: `main.py` — Validates API_KEY is set at startup (prints fatal error and exits if missing)
- **Modified**: `.env.template` — Added API_KEY configuration entry

### Affected endpoints

| Method | Path | Protected |
|--------|------|-----------|
| POST | `/users` | Yes |
| GET | `/users` | Yes |
| GET | `/users/{user_id}` | Yes |
| GET | `/users/@{username}` | Yes |
| PUT | `/users/{user_id}/username` | Yes |
| PUT | `/users/{user_id}/full-name` | Yes |
| DELETE | `/users/{user_id}` | Yes |
| GET | `/healthcheck` | No (intentionally public) |

### Usage

Set the API_KEY environment variable before starting the service:
```bash
export API_KEY=$(python -c 'import secrets; print(secrets.token_urlsafe(32))')
```

Clients must include the key in requests:
```bash
curl -H "Authorization: Bearer $API_KEY" http://localhost:5000/users
```